### PR TITLE
BF: AudioStim.close  to not breed ffmpeg processes by moviepy

### DIFF
--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -110,3 +110,8 @@ class AudioStim(Stim):
             path (str): Filename to save audio data to.
         '''
         self.clip.write_audiofile(path, fps=self.sampling_rate)
+
+    def close(self):
+        if self.clip:
+            self.clip.close()
+            self.clip = None


### PR DESCRIPTION
As initially enjoyed by @caravanuden while observing "Too many open files" crash message while iterating over the list of audio files with a few hundreds of them in a simple code like:

```python
from __future__ import print_function
import sys
import os
import time
from glob import glob
from pliers.stimuli import VideoStim, AudioStim
from pliers.extractors import MelspectrogramExtractor


spect = MelspectrogramExtractor()
PID = os.getpid()
print("PID: %d" % PID)
for i, f in enumerate(sys.argv[1:]): # [:1]*1000):
    print("%4d %30s \t#file: %d" % (i, f, len(glob('/proc/%d/fd/*' % PID))), end='\r')
    sys.stdout.flush()
    audio_stim = AudioStim(filename=f, sampling_rate=44100)

    # get spectrogram
    spectral_stim = spect.transform(audio_stim)
    audio_stim.close()
```

We had to add the `.close()` at the end to prevent breeding of ffmpeg zombies.  I am not quite certain why gc didn't pick those up -- something might be holding on to those instances, thus not calling any of the `__del__`s. (in general in python3 it is not reliable to rely on those -- attributes might disappear before actual content of them thus not being able to close them at all).  Overall I was not sure about the life cycle of any object there so this is a minimalistic workaround which worked for us