### PR TITLE
Remove instance of Python2 super

### DIFF
--- a/pliers/extractors/misc.py
+++ b/pliers/extractors/misc.py
@@ -5,29 +5,28 @@ Extractors that operate on Miscellaneous Stims.
 from pliers.stimuli.misc import SeriesStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.utils import listify, isiterable
-import scipy
 import numpy as np
-import pandas as pd
 from importlib import import_module
 import logging
 
+
 class MetricExtractor(Extractor):
-    ''' Extracts summary metrics from SeriesStim using numpy, scipy or custom 
+    ''' Extracts summary metrics from SeriesStim using numpy, scipy or custom
         functions
     Args:
-        functions (str, functions or list): function, string referring to 
+        functions (str, functions or list): function, string referring to
             absolute import path for a function (e.g. 'numpy.mean') or lambda.
-            Function must operate on 1-dimensional numpy arrays and return a 
+            Function must operate on 1-dimensional numpy arrays and return a
             scalar. A list of functions or import strings may also be passed.
         var_names (list): optional list of custom alias names for each metric
         subset_idx (list): subset of Series index labels to compute metric on.
         kwargs: named arguments for function call
-    ''' 
+    '''
 
     _input_type = SeriesStim
     _log_attributes = ('functions', 'subset_idx')
 
-    def __init__(self, functions=None, var_names=None, 
+    def __init__(self, functions=None, var_names=None,
                  subset_idx=None, **kwargs):
         functions = listify(functions)
         if var_names is not None:
@@ -53,8 +52,8 @@ class MetricExtractor(Extractor):
         self.functions = functions
         self.kwargs = kwargs
         self.subset_idx = subset_idx
-        super(MetricExtractor, self).__init__()
-        
+        super().__init__()
+
     def _extract(self, stim):
         outputs = []
         if self.subset_idx is not None:
@@ -73,5 +72,3 @@ class MetricExtractor(Extractor):
                 metrics = np.array(metrics)
             outputs.append(metrics)
         return ExtractorResult([outputs], stim, self, self.var_names)
-            
-            


### PR DESCRIPTION
Minor removal of vestigial Python 2 super call.

Fixes #371 

The rest was taken care of in a recent PR #392 