### PR TITLE
Resample ExtractedFeatures

### DIFF
--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -1,5 +1,6 @@
 from types import GeneratorType
 from os.path import join
+import numpy as np
 
 import pytest
 
@@ -61,9 +62,9 @@ def test_flatten_dict():
 
 def test_resample():
     ext = RMSExtractor()
-    res = ext.transform(join(get_test_data_path(), '/audio/homer.wav'))
+    res = ext.transform(join(get_test_data_path(), 'audio/homer.wav'))
 
-    df = res.to_df()
+    df = res.to_df(format='long')
 
     resampled_df = resample(df, 3)
 

--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from pliers.stimuli import VideoStim
 from pliers.filters import FrameSamplingFilter
-from pliers.utils import batch_iterable, flatten_dict. resample
+from pliers.utils import batch_iterable, flatten_dict, resample
 from pliers.extractors import RMSExtractor
 from pliers import config
 

--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -67,15 +67,18 @@ def test_resample():
 
     resampled_df = resample(df, 3)
 
-    assert set(resampled_df.columns) == {'duration', 'onset', 'rms'}
+    assert set(resampled_df.columns) == {
+        'duration', 'onset', 'feature', 'value'}
+
+    assert resampled_df['feature'].unique() == 'rms'
 
     # This checks that the filtering has happened. If it has not, then
     # this value for this frequency bin will be an alias and have a
     # very different amplitude
-    assert resampled_df[resampled_df.onset == 0]['rms'].values[0] != \
-        df[df.onset == 0]['rms'].values[0]
-    assert resampled_df[resampled_df.onset == 0]['rms'].values[0] != \
-        df[df.onset == 0]['rms'].values[0]
+    assert resampled_df[resampled_df.onset == 0]['value'].values[0] != \
+        df[df.onset == 0]['value'].values[0]
+    assert resampled_df[resampled_df.onset == 0]['value'].values[0] != \
+        df[df.onset == 0]['value'].values[0]
 
-    assert np.allclose(resampled_df[resampled_df.onset == 2]['rms'].values[0],
+    assert np.allclose(resampled_df[resampled_df.onset == 2]['value'].values[0],
                        0.2261582761938699)

--- a/pliers/utils/__init__.py
+++ b/pliers/utils/__init__.py
@@ -3,7 +3,7 @@
 from .base import (listify, flatten, batch_iterable, classproperty, isiterable,
                    isgenerator, progress_bar_wrapper, attempt_to_import,
                    EnvironmentKeyMixin, verify_dependencies, set_iterable_type,
-                   APIDependent, flatten_dict)
+                   APIDependent, flatten_dict, resample)
 
 
 __all__ = [
@@ -19,5 +19,6 @@ __all__ = [
     'EnvironmentKeyMixin',
     'verify_dependencies',
     'set_iterable_type',
-    'APIDependent'
+    'APIDependent',
+    'resample'
 ]


### PR DESCRIPTION
I took a stab at implementing #426 , mostly copying over the logic from pybids.

I decided to combine the upsample and resample logic, although I could see the argument against (although I also find it hard to "detect" the current sampling rate, so it seems easier to simply upsample it). 



Still need to:
 - Do the operation in place (e.g. replace the data in the `ExtractedFeature` object)
 - Consider `object_id` and other cases that could screw this logic up
 - Add to `Graph`

I think otherwise it's fairly close to the logic being implemented by pybids, however, something about the results seem a bit funny to me.

Take this example:
```
from pliers.extractors import RMSExtractor 
from pliers.tests.utils import get_test_data_path   

ext = RMSExtractor()

res = ext.transform(get_test_data_path() + '/audio/homer.wav')    

In [18]: res.to_df()                                                                                                  
Out[18]: 
    order  duration     onset  object_id       rms
0       0   0.04644  0.000000          0  0.009556
1       1   0.04644  0.046440          0  0.028694
2       2   0.04644  0.092880          0  0.045152
3       3   0.04644  0.139320          0  0.053220
4       4   0.04644  0.185760          0  0.059779
..    ...       ...       ...        ...       ...
69     69   0.04644  3.204354          0  0.020420
70     70   0.04644  3.250794          0  0.016727
71     71   0.04644  3.297234          0  0.007110
72     72   0.04644  3.343673          0  0.004508
73     73   0.04644  3.390113          0  0.004065

In [19]: res.resample(2)                                                                                              
Out[19]: 
   onset  duration       rms
0    0.0       0.5  0.009556
1    0.5       0.5  0.050444
2    1.0       0.5  0.115955
3    1.5       0.5  0.223625
4    2.0       0.5  0.143149
5    2.5       0.5  0.169563
6    3.0       0.5  0.000000
```

It seems that the first sample is in fact only derived from the first value, whereas the last sample is not reflecting all the values ranging from 3-3.5s.

I imagine the most important variable here would be `x_new` which is the output of `np.linspace(0, n - 1, num=num)`

For this example, the value is:

```
ipdb> x_new                                                                                                           
array([   0.        ,  572.66666667, 1145.33333333, 1718.        ,
       2290.66666667, 2863.33333333, 3436.        ])
```

Given that these values reflect the original time in seconds * 1000, I would imagine the first value of `0` is why the first resampled value only reflects the first value. However, given the last value being 3436, I'm surprised the final value is `0` and doesn't reflect the final values from 3-3.5s.

Any ideas? I'll dig in further just taking a break for now, need to understand better now interp1d works.


