### PR TITLE
remove deprecated pandas methods

### DIFF
--- a/pliers/diagnostics/diagnostics.py
+++ b/pliers/diagnostics/diagnostics.py
@@ -179,9 +179,9 @@ class Diagnostics:
             if diagnostic == 'CorrelationMatrix':
                 result = result.copy()
                 np.fill_diagonal(result.values, 0)
-            return result.applymap(thresh).sum().nonzero()[0]
+            return result.applymap(thresh).sum().to_numpy().nonzero()[0]
         else:
-            return result.apply(thresh).nonzero()[0]
+            return result.apply(thresh).to_numpy().nonzero()[0]
 
     def flag_all(self, thresh_dict=None, include=None, exclude=None):
         '''

--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -69,8 +69,8 @@ def test_resample():
     # Test downsample
     downsampled_df = resample(df, 3)
 
-    assert np.allclose(downsampled_df.ix[0].onset, 0)
-    assert np.allclose(downsampled_df.ix[1].onset, 0.33333)
+    assert np.allclose(downsampled_df.iloc[0].onset, 0)
+    assert np.allclose(downsampled_df.iloc[1].onset, 0.33333)
 
     assert set(downsampled_df.columns) == {
         'duration', 'onset', 'feature', 'value'}
@@ -96,8 +96,8 @@ def test_resample():
 
     upsampled_df = resample(df, 10)
 
-    assert np.allclose(upsampled_df.ix[0].onset, 0)
-    assert np.allclose(upsampled_df.ix[1].onset, 0.1)
+    assert np.allclose(upsampled_df.iloc[0].onset, 0)
+    assert np.allclose(upsampled_df.iloc[1].onset, 0.1)
 
     assert set(upsampled_df.columns) == {
         'duration', 'onset', 'feature', 'value'}

--- a/pliers/utils/scikit.py
+++ b/pliers/utils/scikit.py
@@ -52,4 +52,4 @@ class PliersTransformer(SklearnBase):
         self.metadata_ = result[extra_columns]
         result.drop(extra_columns, axis=1, inplace=True, errors='ignore')
 
-        return result.as_matrix()
+        return result.values()

--- a/pliers/utils/scikit.py
+++ b/pliers/utils/scikit.py
@@ -52,4 +52,4 @@ class PliersTransformer(SklearnBase):
         self.metadata_ = result[extra_columns]
         result.drop(extra_columns, axis=1, inplace=True, errors='ignore')
 
-        return result.values()
+        return result.to_numpy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-magic
 numpy>=1.13
 nltk>=3.0
 moviepy>=0.2
-pandas~=0.25
+pandas
 pillow
 requests
 scipy>=0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-magic
 numpy>=1.13
 nltk>=3.0
 moviepy>=0.2
-pandas
+pandas>=0.24
 pillow
 requests
 scipy>=0.13


### PR DESCRIPTION
Closes #437

Calls to deprecated `ix`, `nonzero` and `as_matrix` have been replaced by supported methods (`iloc`, `to_numpy`), tests are now passing (and hey, GitHub actions is great!)

@tyarkoni @adelavega - I've set `pandas>=0.24` in the requirements file. Done some local testing, and that seems to be the earliest version supporting the new methods. But we could also be more conservative and set to `>=1.0` -  any thoughts on that?

Other than that should be ready to merge.