### PR TITLE
replace BERT with lighter extractor in metric extractor tests

### DIFF
--- a/pliers/tests/extractors/test_misc_extractors.py
+++ b/pliers/tests/extractors/test_misc_extractors.py
@@ -1,6 +1,7 @@
-from pliers.extractors import (MetricExtractor, BertLMExtractor,
+from pliers.extractors import (MetricExtractor, 
+                               VADERSentimentExtractor,
                                merge_results)
-from pliers.stimuli import SeriesStim, ComplexTextStim
+from pliers.stimuli import SeriesStim, TextStim
 from pliers.tests.utils import get_test_data_path
 import numpy as np
 import scipy
@@ -72,13 +73,12 @@ def test_metric_extractor():
     assert r_lambda_df['custom_function'][0] == -4
 
 
-# Change test to use simpler extractor
-@pytest.mark.skipif(
-    environ.get('skip_high_memory', False) == 'true', reason='high memory')
 def test_metric_er_as_stim():
-    stim = ComplexTextStim(text='This is [MASK] test')
-    ext_bert = BertLMExtractor(return_softmax=True)
-    ext_metric = MetricExtractor(functions='numpy.sum')
-    r = ext_metric.transform(ext_bert.transform(stim))
+    stim = TextStim(text='This is a test')
+    ext_sent = VADERSentimentExtractor()
+    ext_metric = MetricExtractor(functions='numpy.sum', 
+                                 subset_idx=[f'sentiment_{d}' 
+                                             for d in ['neg','pos','neu']])
+    r = ext_metric.transform(ext_sent.transform(stim))
     df = merge_results(r, extractor_names=False)
     assert np.isclose(df['sum'][0], 1)

--- a/pliers/tests/test_io.py
+++ b/pliers/tests/test_io.py
@@ -2,7 +2,7 @@ from os.path import join
 
 import pytest
 
-from .utils import get_test_data_path
+from pliers.tests.utils import get_test_data_path
 from pliers.stimuli import load_stims
 
 def test_magic_loader():
@@ -21,12 +21,12 @@ def test_magic_loader2():
     text_file = join(get_test_data_path(), 'text', 'sample_text.txt')
     video_url = 'https://archive.org/download/DisneyCastletest/Disney_Castle_512kb.mp4'
     audio_url = 'http://www.bobainsworth.com/wav/simpsons/themodyn.wav'
-    image_url = 'https://www.whitehouse.gov/sites/whitehouse.gov/files/images/twitter_cards_potus.jpg'
+    image_url = 'https://archive.org/download/NIX-C-1987-11903/1987_11903L.jpg'
     text_url = 'https://github.com/tyarkoni/pliers/blob/master/README.md'
     stims = load_stims([text_file, video_url, audio_url, image_url, text_url])
     assert len(stims) == 5
     assert stims[1].fps == 30.0
-    assert stims[3].data.shape == (240, 240, 3)
+    assert stims[3].data.shape == (288, 360, 3)
 
 
 def test_loader_nonexistent():

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from .utils import get_test_data_path
+from pliers.tests.utils import get_test_data_path
 from pliers.stimuli import (VideoStim, VideoFrameStim, ComplexTextStim,
                             AudioStim, ImageStim, CompoundStim,
                             TranscribedAudioCompoundStim,
@@ -273,9 +273,9 @@ def test_remote_stims():
     audio = AudioStim(url=url)
     assert round(audio.duration) == 3
 
-    url = 'https://www.whitehouse.gov/sites/whitehouse.gov/files/images/twitter_cards_potus.jpg'
+    url = 'https://archive.org/download/NIX-C-1987-11903/1987_11903L.jpg'
     image = ImageStim(url=url)
-    assert image.data.shape == (240, 240, 3)
+    assert image.data.shape == (288, 360, 3)
 
     url = 'https://github.com/tyarkoni/pliers/blob/master/README.md'
     text = TextStim(url=url)


### PR DESCRIPTION
Closes https://github.com/PsychoinformaticsLab/pliers/issues/440
Replacing `BertLMExtractor` with `VADERSentimentExtractor`.