### PR TITLE
[enh] support non-English transcript with RevAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env.list
 docs/_build/
 docs/generated/
 .pytest_cache/
+.vscode/

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -24,6 +24,6 @@ tensorflow>=2.4.0
 torch
 transformers
 xlrd
-rev_ai
+rev_ai >= 2.11.0
 tensorflow-hub
 tensorflow_text

--- a/pliers/tests/converters/api/test_revai_converters.py
+++ b/pliers/tests/converters/api/test_revai_converters.py
@@ -28,3 +28,7 @@ def test_googleAPI_converter():
 
     conv = RevAISpeechAPIConverter(access_token='badtoken')
     assert not conv.validate_keys()
+
+    conv = RevAISpeechAPIConverter(language='ex')  # pass unsupported lang
+    with pytest.raises(Exception):
+        conv.transform(stim)


### PR DESCRIPTION
Closes #479.

- Adds a new `language` parameter to `RevAISpeechAPIConverter`, taking str values documented in the [API docs](https://docs.rev.ai/api/asynchronous/reference/#operation/SubmitTranscriptionJob!ct=application/json&path=language&t=request).
- Sets a minimum version of the `rev_ai` python SDK
- Implements a smoke test that non-supported languages error on conversion.