### PR TITLE
Add TFHubAudioExtractor + SPICE Tests

### DIFF
--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -63,7 +63,7 @@ from .image import (BrightnessExtractor, SaliencyExtractor, SharpnessExtractor,
 from .misc import MetricExtractor
 from .models import (TensorFlowKerasApplicationExtractor, 
                      TFHubImageExtractor, TFHubTextExtractor, 
-                     TFHubExtractor)
+                     TFHubExtractor, TFHubAudioExtractor)
 from .text import (ComplexTextExtractor, DictionaryExtractor,
                    PredefinedDictionaryExtractor, LengthExtractor,
                    NumUniqueWordsExtractor, PartOfSpeechExtractor,
@@ -128,6 +128,7 @@ __all__ = [
     'TFHubExtractor',
     'TFHubImageExtractor',
     'TFHubTextExtractor',
+    'TFHubAudioExtractor',
     'ComplexTextExtractor',
     'DictionaryExtractor',
     'PredefinedDictionaryExtractor',

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -120,8 +120,9 @@ class TFHubExtractor(Extractor):
         Returns:
             onsets: onsets of the output
             durations: durations of the output        
+            order: order of the output
         """
-        return None, None
+        return None, None, None
         
     def _extract(self, stim):
         inp = self._preprocess(stim)
@@ -135,11 +136,11 @@ class TFHubExtractor(Extractor):
 
         out = self._postprocess(out)
                 
-        onsets, durations = self._get_timing(out, stim)
+        onsets, durations, order = self._get_timing(out, stim)
 
         return ExtractorResult(listify(out), stim, self, 
                                onsets=onsets, durations=durations,
-                               features=features)
+                               features=features, order=order)
     
     def _to_df(self, result):
         if len(result.features) == 1:
@@ -210,6 +211,10 @@ class TFHubAudioExtractor(TFHubExtractor):
 
     def _get_timing(self, out, stim):
         """ Returns the timing of the output. 
+
+        Assumes model returns a fixed sampling frequency,
+        and deduces durations and onsets from the sampling frequency.
+
         Args:
             out: output of the model
             stim: input stimulus
@@ -221,8 +226,9 @@ class TFHubAudioExtractor(TFHubExtractor):
 
         durations = [stim.duration / out.shape[0]] * out.shape[0]
         onsets = np.arange(0, stim.duration, durations[0]).tolist()
+        order = range(0, len(onsets))
 
-        return onsets, durations
+        return onsets, durations, order
 
 class TFHubTextExtractor(TFHubExtractor):
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -118,9 +118,11 @@ class TFHubExtractor(Extractor):
         # If output is a dict and no output key, return all keys
         if isinstance(out, dict):
             out = np.vstack(list(out.values())).T
-
+        elif isinstance(out, tf.Tensor):
+            out = out.numpy()
+        
         # Always squeeze last dimension if it is 1
-        out = out.numpy().squeeze()
+        out = out.squeeze()
 
         if self.transform_out:
             out = self.transform_out(out)

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -110,7 +110,8 @@ class TFHubExtractor(Extractor):
             durations: durations of the output        
             orders: order of the output
         """
-        return None, None, None
+
+        return stim.onset, stim.duration, None
         
     def _extract(self, stim):
         inp = self._preprocess(stim)
@@ -213,7 +214,10 @@ class TFHubAudioExtractor(TFHubExtractor):
         """
 
         durations = [stim.duration / out.shape[0]] * out.shape[0]
-        onsets = np.arange(0, stim.duration, durations[0]).tolist()
+        onsets = np.arange(0, stim.duration, durations[0])
+        if stim.onset is not None:
+            onsets += stim.onset
+        onsets = onsets.tolist()
         orders = range(0, len(onsets))
 
         return onsets, durations, orders

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -26,10 +26,6 @@ class TFHubExtractor(Extractor):
     Args:
         url_or_path (str): url or path to TFHub model. You can
             browse models at https://tfhub.dev/.
-        load_type (optional): whether to load the model as a KerasLayer
-            or as a SavedModel. If 'keras', loads as a KerasLayer. If
-            'saved_model', loads as a SavedModel.
-        signature (optional): signature to use when loading a SavedModel.
         features (optional): list of feature names matching output dimensions
             
             For example, for a classification model with 1000 output classes 
@@ -63,21 +59,13 @@ class TFHubExtractor(Extractor):
 
     def __init__(self, url_or_path, features=None,
                  transform_out=None, transform_inp=None,
-                 load_type='keras', signature=None,
                  keras_kwargs=None):
         verify_dependencies(['tensorflow_hub'])
         if keras_kwargs is None:
             keras_kwargs = {}
         self.keras_kwargs = keras_kwargs
-        self.load_type = load_type
 
-        if load_type == 'keras':
-            self.model = hub.KerasLayer(url_or_path, **keras_kwargs)
-        elif load_type == 'saved_model':
-            model = hub.load(url_or_path)
-            if signature is None:
-                signature = list(model.signatures.keys())[0]
-            self.model = model.signatures[signature]
+        self.model = hub.KerasLayer(url_or_path, **keras_kwargs)
 
         self.url_or_path = url_or_path
         self.features = features
@@ -130,9 +118,8 @@ class TFHubExtractor(Extractor):
 
         features = self.get_feature_names(out)
 
-        if self.load_type == 'saved_model':
-            if isinstance(out, dict):
-                out = np.vstack(out.values()).T
+        if isinstance(out, dict):
+            out = np.vstack(list(out.values())).T
 
         out = self._postprocess(out)
                 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -120,7 +120,7 @@ class TFHubExtractor(Extractor):
         Returns:
             onsets: onsets of the output
             durations: durations of the output        
-            order: order of the output
+            orders: order of the output
         """
         return None, None, None
         
@@ -136,11 +136,11 @@ class TFHubExtractor(Extractor):
 
         out = self._postprocess(out)
                 
-        onsets, durations, order = self._get_timing(out, stim)
+        onsets, durations, orders = self._get_timing(out, stim)
 
         return ExtractorResult(listify(out), stim, self, 
                                onsets=onsets, durations=durations,
-                               features=features, order=order)
+                               features=features, orders=order)
     
     def _to_df(self, result):
         if len(result.features) == 1:
@@ -221,14 +221,15 @@ class TFHubAudioExtractor(TFHubExtractor):
 
         Returns:
             onsets: onsets of the output
-            durations: durations of the output        
+            durations: durations of the output 
+            orders: order of the output       
         """
 
         durations = [stim.duration / out.shape[0]] * out.shape[0]
         onsets = np.arange(0, stim.duration, durations[0]).tolist()
-        order = range(0, len(onsets))
+        orders = range(0, len(onsets))
 
-        return onsets, durations, order
+        return onsets, durations, orders
 
 class TFHubTextExtractor(TFHubExtractor):
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.filters.image import ImageResizingFilter
-from pliers.stimuli import ImageStim, TextStim
+from pliers.stimuli import ImageStim, TextStim, AudioStim
 from pliers.stimuli.base import Stim
 from pliers.support.exceptions import MissingDependencyError
 from pliers.utils import (attempt_to_import, verify_dependencies,
@@ -26,30 +26,31 @@ class TFHubExtractor(Extractor):
     Args:
         url_or_path (str): url or path to TFHub model. You can
             browse models at https://tfhub.dev/.
-        features (optional): list of labels (for classification) 
-            or other feature names. The number of items must 
-            match the number of features in the output. For example,
-            if a classification model with 1000 output classes is passed 
+        load_type (optional): whether to load the model as a KerasLayer
+            or as a SavedModel. If 'keras', loads as a KerasLayer. If
+            'saved_model', loads as a SavedModel.
+        signature (optional): signature to use when loading a SavedModel.
+        features (optional): list of feature names matching output dimensions
+            
+            For example, for a classification model with 1000 output classes 
+            this must be a list containing 1000 items.
             (e.g. EfficientNet B6, 
-            see https://tfhub.dev/tensorflow/efficientnet/b6/classification/1), 
-            this must be a list containing 1000 items. If a text encoder 
-            outputting 768-dimensional encoding is passed (e.g. base BERT),
-            this must be a list containing 768 items. Each dimension in the 
-            model output will be returned as a separate feature in the 
-            ExtractorResult.
+            https://tfhub.dev/tensorflow/efficientnet/b6/classification/1), 
+            
             Alternatively, the model output can be packed into a single 
             feature (i.e. a vector) by passing a single-element list 
-            (e.g. ['encoding']) or a string. Along the lines of 
-            the previous examples, if a single feature name is 
-            passed here (e.g. if features=['encoding']) for a TFHub model 
-            that outputs a 768-dimensional encoding, the extractor will 
-            return only one feature named 'encoding', which contains the 
-            encoding vector as a 1-d array wrapped in a list.
+            or a string. For example, for a model that outputs a 
+            768-dimensional encoding, the value 'encoding' will result
+            in a 1-d array wrapped in a list named 'encoding'.
+
             If no value is passed, the extractor will automatically 
             compute the number of features in the model output 
             and return an equal number of features in pliers, labeling
             each feature with a generic prefix + its positional index 
             in the model output (feature_0, feature_1, ... ,feature_n).
+
+            Note that for saved models, the feature names are inferred
+            from the output signature, but can be over-ridden.
         transform_out (optional): function to transform model 
             output for compatibility with extractor result
         transform_inp (optional): function to transform Stim.data 
@@ -62,12 +63,22 @@ class TFHubExtractor(Extractor):
 
     def __init__(self, url_or_path, features=None,
                  transform_out=None, transform_inp=None,
+                 load_type='keras', signature=None,
                  keras_kwargs=None):
         verify_dependencies(['tensorflow_hub'])
         if keras_kwargs is None:
             keras_kwargs = {}
         self.keras_kwargs = keras_kwargs
-        self.model = hub.KerasLayer(url_or_path, **keras_kwargs)
+        self.load_type = load_type
+
+        if load_type == 'keras':
+            self.model = hub.KerasLayer(url_or_path, **keras_kwargs)
+        elif load_type == 'saved_model':
+            model = hub.load(url_or_path)
+            if signature is None:
+                signature = list(model.signatures.keys())[0]
+            self.model = model.signatures[signature]
+
         self.url_or_path = url_or_path
         self.features = features
         self.transform_out = transform_out
@@ -78,8 +89,11 @@ class TFHubExtractor(Extractor):
         if self.features:
             return listify(self.features)
         else:
-            return ['feature_' + str(i) 
-                    for i in range(out.shape[-1])]
+            if isinstance(out, dict):
+                return list(out.keys())
+            else:
+                return ['feature_' + str(i) 
+                        for i in range(out.shape[-1])]
     
     def _preprocess(self, stim):
         if self.transform_inp:
@@ -93,13 +107,22 @@ class TFHubExtractor(Extractor):
     def _postprocess(self, out):
         if self.transform_out:
             out = self.transform_out(out)
-        return out.numpy().squeeze()
+        if not isinstance(out, np.ndarray):
+            out = out.numpy().squeeze()
+        return out
         
     def _extract(self, stim):
         inp = self._preprocess(stim)
         out = self.model(inp)
-        out = self._postprocess(out)
+
         features = self.get_feature_names(out)
+
+        if self.load_type == 'saved_model':
+            if isinstance(out, dict):
+                out = np.vstack(out.values()).T
+
+        out = self._postprocess(out)
+                
         return ExtractorResult(listify(out), stim, self, 
                                features=features)
     
@@ -116,39 +139,59 @@ class TFHubExtractor(Extractor):
 
 class TFHubImageExtractor(TFHubExtractor):
 
-    ''' TFHub Extractor class for image models
+    ''' TFHub Extractor class for image models.
+
+    Note that some models may require specific input shapes.'
+    You can reshape inputs using filters, such as ImageResizingFilter.
+    ImageRescaleFilter.
+
     Args:
         url_or_path (str): url or path to TFHub model
-        features (optional): list of labels (for classification) 
-            or other feature names. If not specified, returns 
-            numbered features (feature_0, feature_1, ... ,feature_n)
-        keras_kwargs (dict): arguments to hub.KerasLayer call
+        input_dtype (optional): dtype of input data. Defaults to tf.float32
     '''
 
     _input_type = ImageStim
-    _log_attributes = ('url_or_path', 'features', 'keras_kwargs')
 
     def __init__(self, 
                  url_or_path, 
-                 features=None,
                  input_dtype=None,
-                 keras_kwargs=None):
+                 **kwargs):
         
         self.input_dtype = input_dtype if input_dtype else tf.float32
-        if keras_kwargs is None:
-            keras_kwargs = {}
-        self.keras_kwargs = keras_kwargs
 
-        logging.warning('Some models may require specific input shapes.'
-                        ' Incompatible shapes may raise errors'
-                        ' at extraction. If needed, you can reshape'
-                        ' your input image using ImageResizingFilter, '
-                        ' and rescale using ImageRescalingFilter')
-        super().__init__(url_or_path, features, keras_kwargs=keras_kwargs)
+        super().__init__(url_or_path, **kwargs)
 
     def _preprocess(self, stim):
         x = tf.convert_to_tensor(stim.data, dtype=self.input_dtype)
         x = tf.expand_dims(x, axis=0)
+        return x
+
+
+class TFHubAudioExtractor(TFHubExtractor):
+
+    ''' TFHub Extractor class for audio models.
+
+    Note that some models may require a specific sampling frequency.'
+    You can resample inputs using AudioResamplingFilter.
+
+    Args:
+        url_or_path (str): url or path to TFHub model
+        input_dtype (optional): dtype of input data. Defaults to tf.float32
+    '''
+
+    _input_type = AudioStim
+
+    def __init__(self, 
+                 url_or_path, 
+                 input_dtype=None,
+                 **kwargs):
+        
+        self.input_dtype = input_dtype if input_dtype else tf.float32
+
+        super().__init__(url_or_path, **kwargs)
+
+    def _preprocess(self, stim):
+        x = tf.convert_to_tensor(stim.data, dtype=self.input_dtype)
         return x
 
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -140,7 +140,7 @@ class TFHubExtractor(Extractor):
 
         return ExtractorResult(listify(out), stim, self, 
                                onsets=onsets, durations=durations,
-                               features=features, orders=order)
+                               features=features, orders=orders)
     
     def _to_df(self, result):
         if len(result.features) == 1:

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -110,6 +110,18 @@ class TFHubExtractor(Extractor):
         if not isinstance(out, np.ndarray):
             out = out.numpy().squeeze()
         return out
+
+    def _get_timing(self, out, stim):
+        """ Returns the timing of the output. 
+        Args:
+            out: output of the model
+            stim: input stimulus
+
+        Returns:
+            onsets: onsets of the output
+            durations: durations of the output        
+        """
+        return None, None
         
     def _extract(self, stim):
         inp = self._preprocess(stim)
@@ -123,7 +135,10 @@ class TFHubExtractor(Extractor):
 
         out = self._postprocess(out)
                 
+        onsets, durations = self._get_timing(out, stim)
+
         return ExtractorResult(listify(out), stim, self, 
+                               onsets=onsets, durations=durations,
                                features=features)
     
     def _to_df(self, result):
@@ -166,7 +181,6 @@ class TFHubImageExtractor(TFHubExtractor):
         x = tf.expand_dims(x, axis=0)
         return x
 
-
 class TFHubAudioExtractor(TFHubExtractor):
 
     ''' TFHub Extractor class for audio models.
@@ -194,6 +208,21 @@ class TFHubAudioExtractor(TFHubExtractor):
         x = tf.convert_to_tensor(stim.data, dtype=self.input_dtype)
         return x
 
+    def _get_timing(self, out, stim):
+        """ Returns the timing of the output. 
+        Args:
+            out: output of the model
+            stim: input stimulus
+
+        Returns:
+            onsets: onsets of the output
+            durations: durations of the output        
+        """
+
+        durations = [stim.duration / out.shape[0]] * out.shape[0]
+        onsets = np.arange(0, stim.duration, durations[0]).tolist()
+
+        return onsets, durations
 
 class TFHubTextExtractor(TFHubExtractor):
 

--- a/pliers/tests/extractors/test_model_extractors.py
+++ b/pliers/tests/extractors/test_model_extractors.py
@@ -454,7 +454,8 @@ def test_spice_extractor():
     audio_filter = AudioResamplingFilter(target_sr=16000)
     audio_resampled = audio_filter.transform(audio_stim)
 
-    ext = TFHubAudioExtractor(SPICE_URL, load_type="saved_model")
+    ext = TFHubAudioExtractor(SPICE_URL, keras_kwargs=dict(
+        signature='serving_default', signature_outputs_as_dict=True))
     r_orig = ext.transform(audio_stim).to_df()
     assert r_orig.shape == (74, 6)
 

--- a/pliers/tests/extractors/test_model_extractors.py
+++ b/pliers/tests/extractors/test_model_extractors.py
@@ -9,6 +9,7 @@ from pliers import config
 from pliers.extractors import (TensorFlowKerasApplicationExtractor,
                                TFHubExtractor,
                                TFHubImageExtractor,
+                               TFHubAudioExtractor,
                                TFHubTextExtractor,
                                BertExtractor,
                                BertSequenceEncodingExtractor,
@@ -40,7 +41,7 @@ GNEWS_URL = 'https://tfhub.dev/google/nnlm-en-dim128-with-normalization/2'
 TOKENIZER_URL = 'https://tfhub.dev/tensorflow/bert_en_uncased_preprocess/2'
 ELECTRA_URL = 'https://tfhub.dev/google/electra_small/2'
 SPEECH_URL = 'https://tfhub.dev/google/speech_embedding/1'
-
+SPICE_URL = 'https://tfhub.dev/google/spice/2'
 
 pytestmark = pytest.mark.skipif(
     environ.get('skip_high_memory', False) == 'true', reason='high memory')
@@ -447,3 +448,20 @@ def test_audioset_extractor(hop_size, top_n, target_sr):
     with pytest.raises(ValueError) as err:
         AudiosetLabelExtractor(top_n=10, labels=labels)
     assert 'Top_n and labels are mutually exclusive' in str(err.value)
+
+def test_spice_extractor():
+    audio_stim = AudioStim(join(AUDIO_DIR, 'homer.wav'))
+    audio_filter = AudioResamplingFilter(target_sr=16000)
+    audio_resampled = audio_filter.transform(audio_stim)
+
+    ext = TFHubAudioExtractor(SPICE_URL, load_type="saved_model")
+    r_orig = ext.transform(audio_stim).to_df()
+    assert r_orig.shape == (74, 6)
+
+    r_orig.onset.min() == 0.0
+    r_orig.duration.min() == r_orig.duration.max() == 0.04594594594594594
+    r_orig.uncertainty[0] == 0.974131
+    r_orig.pitch[0] == 0.171392
+
+
+    


### PR DESCRIPTION
- Adds `TFHubAudioExtractor`
This extractor is very similar to `TFHubImageExtractor` but with 1) slightly different preprocessing 2) infers timing output of model (i.e. onsets, durations) from the output (assumes fixed sampling rate)
- Adds `saved_model` loading to `TFHubExtractor`. Models like `SPICE` are not meant to instantiated as `KerasLayer`. Instead, they must be loaded with `hub.load` and have predefined `signature` where the model is stores, and named vectors as outputs. 

For reference this is the `SPICE` model: https://tfhub.dev/google/spice/